### PR TITLE
Ordinary way to test in README

### DIFF
--- a/.github/run-coverage-tests.sh
+++ b/.github/run-coverage-tests.sh
@@ -104,5 +104,7 @@ echo "${@}" | grep -e "-v" -e "--verbose" >/dev/null && {
 set -eu
 set -o pipefail
 
-cd "$PATH_DIR_PARENT" && \
+echo "Moving current path to: ${PATH_DIR_PARENT}"
+cd "$PATH_DIR_PARENT"
+echo "Current path is: $(pwd)"
 runTests "Testing all the packages" "./..."

--- a/.github/run-coverage-tests.sh
+++ b/.github/run-coverage-tests.sh
@@ -11,6 +11,7 @@
 # -----------------------------------------------------------------------------
 #  Constants
 # -----------------------------------------------------------------------------
+PATH_DIR_PARENT="$(dirname "$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)")"
 SUCCESS=0
 FAILURE=1
 TRUE=0
@@ -103,4 +104,5 @@ echo "${@}" | grep -e "-v" -e "--verbose" >/dev/null && {
 set -eu
 set -o pipefail
 
+cd "$PATH_DIR_PARENT" && \
 runTests "Testing all the packages" "./..."

--- a/.github/run-merge-tests.sh
+++ b/.github/run-merge-tests.sh
@@ -66,7 +66,7 @@ function runGofmt() {
 
 function runGoUnitTests() {
     echo -n '- Go unit tests ... '
-    result=$(./run-tests.sh -v 2>&1) || {
+    result=$(./.github/run-coverage-tests.sh -v 2>&1) || {
         echo 'NG'
         echo "$result" | indentStdIn
         return $FAILURE

--- a/.github/workflows/coverage-tests.yaml
+++ b/.github/workflows/coverage-tests.yaml
@@ -22,4 +22,4 @@ jobs:
             -v $(pwd):/workspaces/Hello-Cobra \
             -w /workspaces/Hello-Cobra \
             test:ci \
-            /bin/bash ./run-tests.sh --verbose
+            /bin/bash ./.github/run-coverage-tests.sh --verbose

--- a/README.md
+++ b/README.md
@@ -15,8 +15,17 @@ This repo is for Golang and `Cobra` beginners like I am. We all know keeping 100
 ## How to run tests
 
 ```shellsession
-$ /bin/bash ./run-tests.sh --verbose
+$ go test -cover ./...
+ok    github.com/KEINOS/Hello-Cobra      0.014s  coverage: 100.0% of statements
+ok    github.com/KEINOS/Hello-Cobra/cmd  0.009s  coverage: 100.0% of statements
 ```
+
+- If you find hard which/where to cover when coverage was less than 100%, then try:
+
+  ```shellsession
+  $ /bin/bash ./.github/run-coverage-tests.sh --verbose
+  ...
+  ```
 
 ## Pull Request (PR)
 
@@ -24,7 +33,7 @@ Any PR that might help Golang newbies understand is welcome.
 
 To evolve the sample through natural selection, if you have any better comments, suggestions, practice, etc., then don't hesitate to PR.
 
-If the PR passes the tests then **it will be merged automatically**. If you feel something against any PR then feel free to counter PR.
+If the PR passes the tests then **it will be merged automatically**. If you feel something against any PR, then feel free to counter PR.
 
 ### Auto-merge Conditions
 
@@ -33,8 +42,8 @@ If the PR passes the tests then **it will be merged automatically**. If you feel
 - Pass the "`./.github/run-merge-tests.sh`" which includes the below.
   - Lint check. (`*.sh`, `*.go`)
   - Static analysis. (`*.sh`, `*.go`)
-  - Unit tests of Go. (`./run-tests.sh`)
-- 100% Code Coverage (`./run-tests.sh --verbose`)
+  - Unit tests of Go. (`go test ./...`)
+- 100% Code Coverage (`./.github/run-coverage-tests.sh --verbose`)
 
 ### Draft PR Suggested
 


### PR DESCRIPTION
It is preferable for beginners to use `go test ./...` rather than a customized shell script in README.md.